### PR TITLE
feat: add default target language environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Or, for more convenient swapping between multiple keys/providers:
 export DEEPL_API_KEY_1="your-api-key-here:fx"
 export TRL_API_KEY="$DEEPL_API_KEY_1"
 ```
-Or, if you have the key defined somewhere else, only choose which one you want
+Or, if you have the key(s) defined somewhere else, only choose which one you want
 to use right before the actual request:
 ```sh
 TRL_API_KEY="$DEEPL_API_KEY_1" trl --target EN --content "test"

--- a/README.md
+++ b/README.md
@@ -34,11 +34,22 @@ Or, for more convenient swapping between multiple keys/providers:
 export DEEPL_API_KEY_1="your-api-key-here:fx"
 export TRL_API_KEY="$DEEPL_API_KEY_1"
 ```
+Or, if you have the key defined somewhere else, only choose which one you want
+to use right before the actual request:
+```sh
+TRL_API_KEY="$DEEPL_API_KEY_1" trl --target EN --content "test"
+```
 
 Alternatively, please enter it into a separate text file in the following
 format, on a new line, and use the `-f` flag to supply the path to this file:
 - In the file, put: `TRL_API_KEY your-api-key-here`
 - When using `trl`, add the option: `-f /path/to/API_KEYS.txt`
+
+Speaking of shell and environment variables, if you find yourself often translating
+into the same target language, you may set a default in your shell config:
+```sh
+export TRL_DEFAULT_TARGET_LANG=en  # or EN, or de, or any other available language's code
+```
 
 
 ## Dependencies

--- a/trl
+++ b/trl
@@ -178,6 +178,7 @@ def get_provider(provider_name: str, api_key: str) -> BaseTranslationProvider:
 
 
 def main():
+    target_default = os.getenv("TRL_DEFAULT_TARGET_LANG")
     parser = argparse.ArgumentParser(
         prog="trl",
         description="Translate phrases quickly using various translation providers",
@@ -195,7 +196,8 @@ def main():
         "-t",
         "--target",
         type=str,
-        required=True,
+        default=target_default,
+        required=(target_default is None),
         help="Two-letter target language code, ex. FR, ES, DE, JA, ...",
     )
     parser.add_argument(


### PR DESCRIPTION
- Added listener for `TRL_DEFAULT_TARGET_LANG` environment variable
- Added an appropriate example to Readme documentation
- Also added another example to API key usage for "ad-hoc" key variable
  selection while in the shell